### PR TITLE
Enable Bi-lingual OTP notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,20 @@ git repository. **Do not repack the file manually** as it will be overwritten by
 You will also have to specify the Gateway Implementation Class to use this notify client, which is: `uk.gov.hmcts.reform.idam.notify.client.NotifyService`.
 
 ## Releases
+
 * 1.0 - The initial release.
 * 1.1 - User java opts rather than the system evn variables.
 * 1.2 - Banish json from dependencies to stop interference with Forgerock's libs.
 * 1.3 - Add release notes. Introduce dependency shadowing for a number of dependencies to reduce potential interference. 
-* 1.4 - Add support for language-specific notifications - English and bi-lingual (English and Welsh).
+* 2.0 - Add support for language-specific notifications - English and bi-lingual (English and Welsh).
+
+## Building
+
+Please use the `shadowJar` Gradle goal:
+
+`./gradlew shadowJar`
 
 ## Distribution
+
 Released jars of all versions are available here:
 http://dl.bintray.com/hmcts/hmcts-maven/uk/gov/hmcts/reform/idam/idam-forgerock-notify-client/

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ The Notify client uses two template ids, one for English and one for bi-lingual,
 the same folder as the client. In order to change these values, please make a change in the `cnp-idam-packer`
 git repository. **Do not repack the file manually** as it will be overwritten by Ansible.
 
-1 java opts variable is required:
+2 java opts variables required:
 * `notifyApiKey` - the notification client api key.
+* `notifyApiTemplateId` - the notification client template id (fallback for when there is no language-specific template id).
 
 You will also have to specify the Gateway Implementation Class to use this notify client, which is: `uk.gov.hmcts.reform.idam.notify.client.NotifyService`.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ A custom SMS gateway for ForgeRock. Used for multi-factor authentication.
 
 The Jar lives in the AM instances in the `tomcat/webapps/openam/WEB-INF/lib/` folder.
 
-2 java opts variables required:
+The Notify client uses two template ids, one for English and one for bi-lingual, these are taken from the 
+`amAuthHOTP_<locale>.properties` files found in AM's `openam-auth-hotp-6.5.2.2.jar` library located in 
+the same folder as the client. In order to change these values, please make a change in the `cnp-idam-packer`
+git repository. **Do not repack the file manually** as it will be overwritten by Ansible.
+
+1 java opts variable is required:
 * `notifyApiKey` - the notification client api key.
-* `notifyApiTemplateId` - the notification client template id.
 
 You will also have to specify the Gateway Implementation Class to use this notify client, which is: `uk.gov.hmcts.reform.idam.notify.client.NotifyService`.
 
@@ -16,6 +20,7 @@ You will also have to specify the Gateway Implementation Class to use this notif
 * 1.1 - User java opts rather than the system evn variables.
 * 1.2 - Banish json from dependencies to stop interference with Forgerock's libs.
 * 1.3 - Add release notes. Introduce dependency shadowing for a number of dependencies to reduce potential interference. 
+* 1.4 - Add support for language-specific notifications - English and bi-lingual (English and Welsh).
 
 ## Distribution
 Released jars of all versions are available here:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You will also have to specify the Gateway Implementation Class to use this notif
 * 1.1 - User java opts rather than the system evn variables.
 * 1.2 - Banish json from dependencies to stop interference with Forgerock's libs.
 * 1.3 - Add release notes. Introduce dependency shadowing for a number of dependencies to reduce potential interference. 
-* 2.0 - Add support for language-specific notifications - English and bi-lingual (English and Welsh).
+* 1.4 - Add support for language-specific notifications - English and bi-lingual (English and Welsh).
 
 ## Distribution
 Released jars of all versions are available here:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You will also have to specify the Gateway Implementation Class to use this notif
 * 1.1 - User java opts rather than the system evn variables.
 * 1.2 - Banish json from dependencies to stop interference with Forgerock's libs.
 * 1.3 - Add release notes. Introduce dependency shadowing for a number of dependencies to reduce potential interference. 
-* 1.4 - Add support for language-specific notifications - English and bi-lingual (English and Welsh).
+* 2.0 - Add support for language-specific notifications - English and bi-lingual (English and Welsh).
 
 ## Distribution
 Released jars of all versions are available here:

--- a/build.gradle
+++ b/build.gradle
@@ -2,27 +2,25 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
-    id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 group 'uk.gov.hmcts.reform.idam'
 version '1.4'
 
 sourceCompatibility = 1.8
-shadowJar {
+
+jar {
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
     exclude('com/sun/identity/**')
-    relocate 'org.json', 'shadowed.org.json'
-    relocate 'org.joda.time', 'shadowed.org.joda.time'
-    relocate 'org.apache.commons-logging', 'shadowed.org.apache.commons-logging'
-    relocate 'org.apache.commons-codec', 'shadowed.org.apache.commons-codec'
-    relocate 'org.apache.commons-io', 'shadowed.org.apache.commons-io'
 }
 
 repositories {
     mavenCentral()
     jcenter()
     maven {
-        url  "https://dl.bintray.com/gov-uk-notify/maven"
+        url "https://dl.bintray.com/gov-uk-notify/maven"
     }
     maven {
         url 'https://dl.bintray.com/hmcts/hmcts-maven'
@@ -58,7 +56,9 @@ bintray {
 }
 
 dependencies {
-    compile 'uk.gov.service.notify:notifications-java-client:3.15.0-RELEASE'
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    compile('uk.gov.service.notify:notifications-java-client:3.15.0-RELEASE') {
+        exclude module: "json"
+    }
     testCompile "org.mockito:mockito-core:3+"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,25 +2,27 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
+    id "com.github.johnrengelman.shadow" version "5.2.0"
 }
 
 group 'uk.gov.hmcts.reform.idam'
 version '1.4'
 
 sourceCompatibility = 1.8
-
-jar {
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
+shadowJar {
     exclude('com/sun/identity/**')
+    relocate 'org.json', 'shadowed.org.json'
+    relocate 'org.joda.time', 'shadowed.org.joda.time'
+    relocate 'org.apache.commons-logging', 'shadowed.org.apache.commons-logging'
+    relocate 'org.apache.commons-codec', 'shadowed.org.apache.commons-codec'
+    relocate 'org.apache.commons-io', 'shadowed.org.apache.commons-io'
 }
 
 repositories {
     mavenCentral()
     jcenter()
     maven {
-        url "https://dl.bintray.com/gov-uk-notify/maven"
+        url  "https://dl.bintray.com/gov-uk-notify/maven"
     }
     maven {
         url 'https://dl.bintray.com/hmcts/hmcts-maven'
@@ -56,9 +58,7 @@ bintray {
 }
 
 dependencies {
+    compile 'uk.gov.service.notify:notifications-java-client:3.15.0-RELEASE'
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile('uk.gov.service.notify:notifications-java-client:3.15.0-RELEASE') {
-        exclude module: "json"
-    }
     testCompile "org.mockito:mockito-core:3+"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform.idam'
-version '2.0'
+version '1.4'
 
 sourceCompatibility = 1.8
 shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform.idam'
-version '1.3'
+version '1.4'
 
 sourceCompatibility = 1.8
 shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform.idam'
-version '1.4'
+version '2.0'
 
 sourceCompatibility = 1.8
 shadowJar {

--- a/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
@@ -13,18 +13,14 @@ import java.util.Map;
 public class NotifyService implements SMSGateway {
 
     private static final String NOTIFY_KEY = "notifyApiKey";
-    private static final String NOTIFY_TEMPLATE_ID = "notifyApiTemplateId";
     static final String OTP_CODE_PARAM = "code";
-    private final String notificationClientTemplateId;
     private final NotificationClientApi notificationClient;
 
     public NotifyService() {
-        notificationClientTemplateId = System.getProperty(NOTIFY_TEMPLATE_ID);
         notificationClient = new NotificationClient(System.getProperty(NOTIFY_KEY));
     }
 
     public NotifyService(String notificationClientTemplateId, NotificationClientApi notificationClient) {
-        this.notificationClientTemplateId = notificationClientTemplateId;
         this.notificationClient = notificationClient;
     }
 
@@ -46,11 +42,14 @@ public class NotifyService implements SMSGateway {
     public void sendEmail(String from, String to, String subject, String message, String code, Map options)
             throws AuthLoginException {
 
+        // value set in amAuthHOTP_<locale>.properties - see: SIDM-3931
+        final String languageSpecificNotificationClientTemplateId = subject;
+
         if (to != null) {
             try {
                 Map<String, String> parameters = new HashMap<>();
                 parameters.put(OTP_CODE_PARAM, code);
-                notificationClient.sendEmail(notificationClientTemplateId, to, parameters,"","");
+                notificationClient.sendEmail(languageSpecificNotificationClientTemplateId, to, parameters, "", "");
 
             } catch (NotificationClientException e) {
                 throw new AuthLoginException("Failed to send OTP code to " + to, e);

--- a/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
@@ -22,7 +22,7 @@ public class NotifyService implements SMSGateway {
     private final NotificationClientApi notificationClient;
 
     static {
-        LOGGER.warning("Successfully loaded custom Notify client for OTP.");
+        LOGGER.info("Successfully loaded custom Notify client for OTP.");
     }
 
     public NotifyService() {
@@ -57,7 +57,7 @@ public class NotifyService implements SMSGateway {
 
         final String languageSpecificNotificationClientTemplateId;
 
-        LOGGER.severe(String.format("Sending OTP to: %s, subject: %s", to, subject));
+        LOGGER.fine(String.format("Sending OTP to: %s, subject: %s", to, subject));
 
         // We are hijacking the i18n mechanism here. The language-specific templateId is being passed as message subject.
         // This condition makes it backwards-compatible.

--- a/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
@@ -57,7 +57,7 @@ public class NotifyService implements SMSGateway {
 
         final String languageSpecificNotificationClientTemplateId;
 
-        LOGGER.severe(String.format("Sending OTP to: %s, subject: %s", to, subject));
+        LOGGER.fine(String.format("Sending OTP to: %s, subject: %s", to, subject));
 
         // We are hijacking the i18n mechanism here. The language-specific templateId is being passed as message subject.
         // This condition makes it backwards-compatible.

--- a/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.idam.notify.client;
 
 import com.sun.identity.authentication.modules.hotp.SMSGateway;
 import com.sun.identity.authentication.spi.AuthLoginException;
-import org.apache.commons.lang3.StringUtils;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientApi;
 import uk.gov.service.notify.NotificationClientException;
@@ -22,6 +21,9 @@ public class NotifyService implements SMSGateway {
     private final String notificationClientTemplateId;
     private final NotificationClientApi notificationClient;
 
+    static {
+        LOGGER.warning("Successfully loaded custom Notify client.");
+    }
 
     public NotifyService() {
         notificationClientTemplateId = System.getProperty(NOTIFY_TEMPLATE_ID);
@@ -46,7 +48,6 @@ public class NotifyService implements SMSGateway {
      * @should send email
      * @should do nothing if `to` param is null
      * @should throw exception if sending email throws exception
-     * @should use fallback template id if subject is blank
      * @should use fallback template id if subject is default value
      * @should use subject as template id
      */
@@ -56,9 +57,11 @@ public class NotifyService implements SMSGateway {
 
         final String languageSpecificNotificationClientTemplateId;
 
+        LOGGER.severe(String.format("Sending OTP to: %s, subject: %s", to, subject));
+
         // We are hijacking the i18n mechanism here. The language-specific templateId is being passed as message subject.
         // This condition makes it backwards-compatible.
-        if (StringUtils.isBlank(subject) || OPENAM_DEFAULT_SUBJECT.equalsIgnoreCase(subject)) {
+        if (OPENAM_DEFAULT_SUBJECT.equalsIgnoreCase(subject)) {
             LOGGER.warning("Language-specific Notify templateId is not available. Falling back to the one supplied in env.");
             languageSpecificNotificationClientTemplateId = notificationClientTemplateId;
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/notify/client/NotifyService.java
@@ -22,7 +22,7 @@ public class NotifyService implements SMSGateway {
     private final NotificationClientApi notificationClient;
 
     static {
-        LOGGER.warning("Successfully loaded custom Notify client.");
+        LOGGER.warning("Successfully loaded custom Notify client for OTP.");
     }
 
     public NotifyService() {
@@ -57,7 +57,7 @@ public class NotifyService implements SMSGateway {
 
         final String languageSpecificNotificationClientTemplateId;
 
-        LOGGER.fine(String.format("Sending OTP to: %s, subject: %s", to, subject));
+        LOGGER.severe(String.format("Sending OTP to: %s, subject: %s", to, subject));
 
         // We are hijacking the i18n mechanism here. The language-specific templateId is being passed as message subject.
         // This condition makes it backwards-compatible.

--- a/src/test/java/uk/gov/hmcts/reform/idam/notify/client/NotifyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/notify/client/NotifyServiceTest.java
@@ -1,15 +1,20 @@
 package uk.gov.hmcts.reform.idam.notify.client;
 
+import com.sun.identity.authentication.spi.AuthLoginException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.service.notify.NotificationClientApi;
+import uk.gov.service.notify.NotificationClientException;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.reform.idam.notify.client.NotifyService.OTP_CODE_PARAM;
@@ -20,7 +25,9 @@ public class NotifyServiceTest {
     private static final String AN_EMAIL = "john@doe.com";
     private static final String CODE = "12345";
     private static final String TEMPLATE_ID = "67ace669-93b5-4055-88b2-c136c63c5511";
-    private final Map<String, String> params  = new HashMap<String, String>() {{ put(OTP_CODE_PARAM, CODE); }};
+    private final Map<String, String> params = new HashMap<String, String>() {{
+        put(OTP_CODE_PARAM, CODE);
+    }};
 
     @Mock
     private NotificationClientApi notificationClient;
@@ -71,5 +78,48 @@ public class NotifyServiceTest {
     public void sendSMSMessage_shouldSendEmail() throws Exception {
         notifyService.sendSMSMessage(null, AN_EMAIL, TEMPLATE_ID, "", CODE, null);
         verify(notificationClient).sendEmail(TEMPLATE_ID, AN_EMAIL, params, "", "");
+    }
+
+    /**
+     * @verifies use fallback template id if subject is blank
+     * @see NotifyService#sendEmail(String, String, String, String, String, Map)
+     */
+    @Test
+    public void sendEmail_shouldUseFallbackTemplateIdIfSubjectIsBlank() throws AuthLoginException, NotificationClientException {
+        final NotificationClientApi clientMock = mock(NotificationClientApi.class);
+        final String testTemplateId = "test";
+        final NotifyService notifyService = new NotifyService(testTemplateId, clientMock);
+
+        notifyService.sendEmail(AN_EMAIL, AN_EMAIL, "  ", null, CODE, null);
+        verify(clientMock).sendEmail(eq(testTemplateId), eq(AN_EMAIL), eq(params), any(), any());
+    }
+
+    /**
+     * @verifies use fallback template id if subject is default value
+     * @see NotifyService#sendEmail(String, String, String, String, String, Map)
+     */
+    @Test
+    public void sendEmail_shouldUseFallbackTemplateIdIfSubjectIsDefaultValue() throws AuthLoginException, NotificationClientException {
+        final NotificationClientApi clientMock = mock(NotificationClientApi.class);
+        final String testTemplateId = "test";
+        final NotifyService notifyService = new NotifyService(testTemplateId, clientMock);
+
+        notifyService.sendEmail(AN_EMAIL, AN_EMAIL, NotifyService.OPENAM_DEFAULT_SUBJECT, null, CODE, null);
+        verify(clientMock).sendEmail(eq(testTemplateId), eq(AN_EMAIL), eq(params), any(), any());
+    }
+
+    /**
+     * @verifies use subject as template id
+     * @see NotifyService#sendEmail(String, String, String, String, String, Map)
+     */
+    @Test
+    public void sendEmail_shouldUseSubjectAsTemplateId() throws AuthLoginException, NotificationClientException {
+        final NotificationClientApi clientMock = mock(NotificationClientApi.class);
+        final String testTemplateId = "test";
+        final NotifyService notifyService = new NotifyService(testTemplateId, clientMock);
+
+        final String suppliedTemplateId = "actual template id";
+        notifyService.sendEmail(AN_EMAIL, AN_EMAIL, suppliedTemplateId, null, CODE, null);
+        verify(clientMock).sendEmail(eq(suppliedTemplateId), eq(AN_EMAIL), eq(params), any(), any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/idam/notify/client/NotifyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/notify/client/NotifyServiceTest.java
@@ -81,20 +81,6 @@ public class NotifyServiceTest {
     }
 
     /**
-     * @verifies use fallback template id if subject is blank
-     * @see NotifyService#sendEmail(String, String, String, String, String, Map)
-     */
-    @Test
-    public void sendEmail_shouldUseFallbackTemplateIdIfSubjectIsBlank() throws AuthLoginException, NotificationClientException {
-        final NotificationClientApi clientMock = mock(NotificationClientApi.class);
-        final String testTemplateId = "test";
-        final NotifyService notifyService = new NotifyService(testTemplateId, clientMock);
-
-        notifyService.sendEmail(AN_EMAIL, AN_EMAIL, "  ", null, CODE, null);
-        verify(clientMock).sendEmail(eq(testTemplateId), eq(AN_EMAIL), eq(params), any(), any());
-    }
-
-    /**
      * @verifies use fallback template id if subject is default value
      * @see NotifyService#sendEmail(String, String, String, String, String, Map)
      */

--- a/src/test/java/uk/gov/hmcts/reform/idam/notify/client/NotifyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/notify/client/NotifyServiceTest.java
@@ -38,7 +38,7 @@ public class NotifyServiceTest {
      */
     @Test
     public void sendEmail_shouldSendEmail() throws Exception {
-        notifyService.sendEmail(null, AN_EMAIL, null, "", CODE, null);
+        notifyService.sendEmail(null, AN_EMAIL, TEMPLATE_ID, "", CODE, null);
         verify(notificationClient).sendEmail(TEMPLATE_ID, AN_EMAIL, params, "", "");
     }
 
@@ -59,7 +59,7 @@ public class NotifyServiceTest {
      */
     @Test
     public void sendEmail_shouldThrowExceptionIfSendingEmailThrowsException() throws Exception {
-        notifyService.sendEmail(null, AN_EMAIL, null, "", CODE, null);
+        notifyService.sendEmail(null, AN_EMAIL, TEMPLATE_ID, "", CODE, null);
         verify(notificationClient).sendEmail(TEMPLATE_ID, AN_EMAIL, params, "", "");
     }
 
@@ -69,7 +69,7 @@ public class NotifyServiceTest {
      */
     @Test
     public void sendSMSMessage_shouldSendEmail() throws Exception {
-        notifyService.sendSMSMessage(null, AN_EMAIL, null, "", CODE, null);
+        notifyService.sendSMSMessage(null, AN_EMAIL, TEMPLATE_ID, "", CODE, null);
         verify(notificationClient).sendEmail(TEMPLATE_ID, AN_EMAIL, params, "", "");
     }
 }


### PR DESCRIPTION
### https://tools.hmcts.net/jira/browse/SIDM-3931 ###

### Change description ###

Enable usage of the subject field to internationalise OTP notifications.

The new version **is** backwards compatible and can be deployed separately to the other Welsh changes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```